### PR TITLE
github: s9a

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 github: s9a
-open_collective: s9a


### PR DESCRIPTION
keep just [our github sponsors](https://github.com/sponsors/s9a) because [oc dissolved](https://blog.opencollective.com/open-collective-official-statement-ocf-dissolution/)